### PR TITLE
Fixed image uploading. Both URL and a file

### DIFF
--- a/src/Client/Image/ImageFileUpload.php
+++ b/src/Client/Image/ImageFileUpload.php
@@ -31,7 +31,22 @@ final class ImageFileUpload implements ImageUploadRequestInterface
     {
         $this->validateFile($filename);
         $this->imageFormat = self::ALLOWED_FILE_TYPES[exif_imagetype($filename)];
-        $this->imageData = iconv('UTF-8', 'UTF-8//IGNORE', utf8_encode(file_get_contents($filename)));
+        $this->imageData = $this->byteArray($filename);
+    }
+
+    /**
+     *  Generate byte array similar to the one in C# and Java
+     */
+    public function byteArray(string $filename): array
+    {
+        $data   = file_get_contents($filename);
+        $array  = array();
+        foreach(str_split($data) as $char)
+        {
+            array_push($array, ord($char));
+        }
+
+        return $array;
     }
 
     public function getPostBodyData(): string

--- a/src/Client/Image/ImageUrlUpload.php
+++ b/src/Client/Image/ImageUrlUpload.php
@@ -6,17 +6,30 @@ namespace LauLamanApps\IzettleApi\Client\Image;
 
 final class ImageUrlUpload implements ImageUploadRequestInterface
 {
+    const ALLOWED_FILE_TYPES = [
+        'gif'  => 'GIF',
+        'jpeg' => 'JPEG',
+        'jpg'  => 'JPEG',
+        'png'  => 'PNG',
+        'bmp'  => 'BMP',
+    ];
+
     private $imageUrl;
+    private $imageFormat;
 
     public function __construct(string $imageUrl)
     {
-        $this->imageUrl = $imageUrl;
+        $this->imageUrl     = $imageUrl;
+        $this->imageFormat  = self::ALLOWED_FILE_TYPES[
+            strtolower(array_values(array_slice(explode('.', $imageUrl), -1))[0])
+        ];
     }
 
     public function getPostBodyData(): string
     {
         $data = [
-            'imageUrl' => $this->imageUrl
+            'imageFormat'   => $this->imageFormat,
+            'imageUrl'      => $this->imageUrl
         ];
 
         return json_encode($data);

--- a/src/Client/ImageClient.php
+++ b/src/Client/ImageClient.php
@@ -12,7 +12,7 @@ use Ramsey\Uuid\UuidInterface;
 
 final class ImageClient
 {
-    const BASE_URL = 'https://image.izettle.com/organizations/%s';
+    const BASE_URL = 'https://image.izettle.com/v2/images/organizations/%s';
     const POST_IMAGE = self::BASE_URL . '/products';
 
     private $client;
@@ -25,7 +25,7 @@ final class ImageClient
         ImageBuilderInterface $imageBuilder
     ) {
         $this->client = $client;
-        $this->organizationUuid = (string) $organizationUuid;
+        $this->organizationUuid = $organizationUuid ? (string) $organizationUuid : 'self';
         $this->imageBuilder = $imageBuilder;
     }
 

--- a/tests/Unit/Client/Image/ImageFileUploadTest.php
+++ b/tests/Unit/Client/Image/ImageFileUploadTest.php
@@ -12,6 +12,19 @@ use PHPUnit\Framework\TestCase;
  */
 final class ImageFileUploadTest extends TestCase
 {
+
+    public function byteArray(string $filename): array
+    {
+        $data   = file_get_contents($filename);
+        $array  = array();
+        foreach(str_split($data) as $char)
+        {
+            array_push($array, ord($char));
+        }
+
+        return $array;
+    }
+
     /**
      * @test
      */
@@ -19,7 +32,7 @@ final class ImageFileUploadTest extends TestCase
     {
         $file = dirname(__FILE__) . '/files/50x50-good.png';
         $imageFormat = 'PNG';
-        $imageData = iconv('UTF-8', 'UTF-8//IGNORE', utf8_encode(file_get_contents($file)));
+        $imageData = $this->byteArray($file);
         $productImageUpload = new ImageFileUpload($file);
 
         self::assertInstanceOf(ImageFileUpload::class, $productImageUpload);

--- a/tests/Unit/Client/Image/ImageUrlUploadTest.php
+++ b/tests/Unit/Client/Image/ImageUrlUploadTest.php
@@ -17,12 +17,25 @@ final class ImageUrlUploadTest extends TestCase
      */
     public function productImageUpload_withURL(): void
     {
-        $imageUrl = 'https://example.com/image.png';
+        $allowedImageType = [
+            'gif'  => 'GIF',
+            'jpeg' => 'JPEG',
+            'jpg'  => 'JPEG',
+            'png'  => 'PNG',
+            'bmp'  => 'BMP',
+        ];
+
+        $imageUrl       = 'https://example.com/image.png';
+        $imageFormat    = $allowedImageType[
+            strtolower(array_values(array_slice(explode('.', $imageUrl), -1))[0])
+        ];
 
         $productImageUpload = new ImageUrlUpload($imageUrl);
 
         self::assertInstanceOf(ImageUrlUpload::class, $productImageUpload);
+        self::assertAttributeEquals($imageFormat, 'imageFormat', $productImageUpload);
         self::assertAttributeEquals($imageUrl, 'imageUrl', $productImageUpload);
-        self::assertSame(['imageUrl' => $imageUrl], json_decode($productImageUpload->getPostBodyData(), true));
+        // self::assertSame(['imageUrl' => $imageUrl], json_decode($productImageUpload->getPostBodyData(), true));
+        self::assertSame(['imageFormat' => $imageFormat, 'imageData' => $imageData], json_decode($productImageUpload->getPostBodyData(), true));
     }
 }


### PR DESCRIPTION
Hello
Thank you! You did a great job!
iZettle updated their API documentation. At least new there is correct URL to send images to. 
Also some small changes like uuid in ImageClient was null. 
Also now they require image type even for url, so I had to implement it somehow

Have a good day