### PR TITLE
Add support for online card payments.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-  "name": "laulamanapps/Izettle-api",
+  "name": "laulamanapps/izettle-api",
   "description": "Izettle API PHP Client",
   "license": "MIT",
   "authors": [

--- a/src/API/Purchase/Payment/CardOnlinePayment.php
+++ b/src/API/Purchase/Payment/CardOnlinePayment.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LauLamanApps\IzettleApi\API\Purchase\Payment;
+
+use LauLamanApps\IzettleApi\API\Purchase\AbstractPayment;
+use Money\Money;
+use Ramsey\Uuid\UuidInterface;
+
+final class CardOnlinePayment extends AbstractPayment
+{
+    private $referenceNumber;
+    private $maskedPan;
+    private $cardType;
+    private $cardPaymentEntryMode;
+    private $paymentlinkOrderUuid;
+
+    public function __construct(
+        UuidInterface $uuid,
+        Money $amount,
+        string $referenceNumber,
+        string $maskedPan,
+        string $cardType,
+        string $cardPaymentEntryMode,
+        UuidInterface $paymentlinkOrderUuid
+    ) {
+        parent::__construct($uuid, $amount);
+        $this->referenceNumber = $referenceNumber;
+        $this->maskedPan = $maskedPan;
+        $this->cardType = $cardType;
+        $this->cardPaymentEntryMode = $cardPaymentEntryMode;
+        $this->paymentlinkOrderUuid = $paymentlinkOrderUuid;
+    }
+
+    public function getReferenceNumber(): string
+    {
+        return $this->referenceNumber;
+    }
+
+    public function getMaskedPan(): string
+    {
+        return $this->maskedPan;
+    }
+
+    public function getCardType(): string
+    {
+        return $this->cardType;
+    }
+
+    public function getCardPaymentEntryMode(): string
+    {
+        return $this->cardPaymentEntryMode;
+    }
+
+    public function getPaymentlinkOrderUuid(): UuidInterface
+    {
+        return $this->paymentlinkOrderUuid;
+    }
+}

--- a/src/Client/Purchase/PaymentBuilder.php
+++ b/src/Client/Purchase/PaymentBuilder.php
@@ -7,6 +7,7 @@ namespace LauLamanApps\IzettleApi\Client\Purchase;
 use DateTime;
 use LauLamanApps\IzettleApi\API\Purchase\AbstractPayment;
 use LauLamanApps\IzettleApi\API\Purchase\Payment\CardPayment;
+use LauLamanApps\IzettleApi\API\Purchase\Payment\CardOnlinePayment;
 use LauLamanApps\IzettleApi\API\Purchase\Payment\CashPayment;
 use LauLamanApps\IzettleApi\API\Purchase\Payment\InvoicePayment;
 use LauLamanApps\IzettleApi\API\Purchase\Payment\MobilePayment;
@@ -20,6 +21,7 @@ use Ramsey\Uuid\Uuid;
 final class PaymentBuilder implements PaymentBuilderInterface
 {
     const CARD = 'IZETTLE_CARD';
+    const CARD_ONLINE = 'IZETTLE_CARD_ONLINE';
     const CASH = 'IZETTLE_CASH';
     const INVOICE = 'IZETTLE_INVOICE';
     const MOBILE = 'MOBILE_PAY';
@@ -41,6 +43,8 @@ final class PaymentBuilder implements PaymentBuilderInterface
         switch ($payment['type']) {
             case self::CARD:
                 return $this->parseCardPayment($payment, $currency);
+            case self::CARD_ONLINE:
+                return $this->parseCardOnlinePayment($payment, $currency);
             case self::CASH:
                 return $this->parseCashPayment($payment, $currency);
             case self::INVOICE:
@@ -69,6 +73,19 @@ final class PaymentBuilder implements PaymentBuilderInterface
             $this->getFromKey('applicationIdentifier', $payment['attributes']),
             $this->getFromKey('terminalVerificationResults', $payment['attributes']),
             (int) $this->getFromKey('nrOfInstallments', $payment['attributes'])
+        );
+    }
+
+    private function parseCardOnlinePayment($payment, Currency $currency): CardOnlinePayment
+    {
+        return new CardOnlinePayment(
+            Uuid::fromString($payment['uuid']),
+            new Money($payment['amount'], $currency),
+            $payment['attributes']['referenceNumber'],
+            $payment['attributes']['maskedPan'],
+            $payment['attributes']['cardType'],
+            $payment['attributes']['cardPaymentEntryMode'],
+            Uuid::fromString($payment['attributes']['paymentlinkOrderUuid']),
         );
     }
 

--- a/src/Client/Purchase/PaymentBuilder.php
+++ b/src/Client/Purchase/PaymentBuilder.php
@@ -85,7 +85,7 @@ final class PaymentBuilder implements PaymentBuilderInterface
             $payment['attributes']['maskedPan'],
             $payment['attributes']['cardType'],
             $payment['attributes']['cardPaymentEntryMode'],
-            Uuid::fromString($payment['attributes']['paymentlinkOrderUuid']),
+            Uuid::fromString($payment['attributes']['paymentlinkOrderUuid'])
         );
     }
 

--- a/src/Client/Purchase/PurchaseHistoryBuilder.php
+++ b/src/Client/Purchase/PurchaseHistoryBuilder.php
@@ -20,8 +20,6 @@ final class PurchaseHistoryBuilder implements PurchaseHistoryBuilderInterface
     {
         $data =  json_decode($jsonData, true);
 
-        dump($data);
-
         return new PurchaseHistory(
             $data['firstPurchaseHash'],
             $data['lastPurchaseHash'],

--- a/src/Client/Purchase/PurchaseHistoryBuilder.php
+++ b/src/Client/Purchase/PurchaseHistoryBuilder.php
@@ -20,6 +20,8 @@ final class PurchaseHistoryBuilder implements PurchaseHistoryBuilderInterface
     {
         $data =  json_decode($jsonData, true);
 
+        dump($data);
+
         return new PurchaseHistory(
             $data['firstPurchaseHash'],
             $data['lastPurchaseHash'],


### PR DESCRIPTION
Adds support for payments of type `IZETTLE_CARD_ONLINE`, which are created when a customer uses a [payment link](https://www.izettle.com/gb/help/articles/2935602-payment-links).

Also fixes issue #35 (invalid Composer package name).