### PR TITLE
update enum package to ^3.0

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -8,7 +8,7 @@ checks:
 build:
     environment:
         php:
-            version: 7.1
+            version: 7.3
     tests:
         override:
             -

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: php
 
 php:
-  - '7.1'
+  - '7.3'
+  - '7.4'
 
 dist: trusty
 

--- a/composer.json
+++ b/composer.json
@@ -19,11 +19,11 @@
     }
   },
   "require": {
-    "php": ">=7.1",
+    "php": ">=7.3",
     "guzzlehttp/guzzle": "^6.3",
     "moneyphp/money": "^3.0",
     "ramsey/uuid": "^3.7",
-    "werkspot/enum": "^2.1",
+    "werkspot/enum": "^3.0",
     "ext-json": "*"
   },
   "require-dev": {


### PR DESCRIPTION
The 2.x version of werkspot/enum is bound to doctrine/inflector 1.x, I've already used inflector 2.x and upgrading of enum to v3 seems harmless and more compatible.

Only that it needs PHP 7.3, but perhaps upgrading is not a bad idea either.

Edit: Or does it need to go to the 'releases/1.0-dev' branch? Since the package-name is fixed there as well.