### PR TITLE
Added support for Assertion Grant

### DIFF
--- a/src/Client/AccessToken.php
+++ b/src/Client/AccessToken.php
@@ -13,7 +13,7 @@ final class AccessToken
     private $expires;
     private $refreshToken;
 
-    public function __construct(string $accessToken, DateTimeImmutable $expires, string $refreshToken)
+    public function __construct(string $accessToken, DateTimeImmutable $expires, ?string $refreshToken)
     {
         $this->accessToken = $accessToken;
         $this->expires = $expires;
@@ -35,7 +35,7 @@ final class AccessToken
         return (new DateTime()) > $this->expires;
     }
 
-    public function getRefreshToken(): string
+    public function getRefreshToken(): ?string
     {
         return $this->refreshToken;
     }

--- a/src/Client/Exception/AccessTokenNotRefreshableException.php
+++ b/src/Client/Exception/AccessTokenNotRefreshableException.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LauLamanApps\IzettleApi\Client\Exception;
+
+use Exception;
+use LauLamanApps\IzettleApi\Exception\IzettleApiException;
+use RuntimeException;
+
+final class AccessTokenNotRefreshableException extends RuntimeException implements IzettleApiException
+{
+}

--- a/src/GuzzleIzettleClient.php
+++ b/src/GuzzleIzettleClient.php
@@ -14,6 +14,7 @@ use LauLamanApps\IzettleApi\API\Universal\IzettlePostable;
 use LauLamanApps\IzettleApi\Client\AccessToken;
 use LauLamanApps\IzettleApi\Client\ApiScope;
 use LauLamanApps\IzettleApi\Client\Exception\AccessTokenExpiredException;
+use LauLamanApps\IzettleApi\Client\Exception\AccessTokenNotRefreshableException;
 use LauLamanApps\IzettleApi\Client\Exception\GuzzleClientExceptionHandler;
 use LauLamanApps\IzettleApi\Exception\UnprocessableEntityException;
 use Psr\Http\Message\ResponseInterface;
@@ -130,12 +131,18 @@ class GuzzleIzettleClient implements IzettleClientInterface
     public function refreshAccessToken(?AccessToken $accessToken =  null): AccessToken
     {
         $accessToken = $accessToken ?? $this->accessToken;
+
+        $refreshToken = $accessToken->getRefreshToken();
+        if ($refreshToken === null) {
+            throw new AccessTokenNotRefreshableException('This access token cannot be renewed.');
+        }
+
         $options = [
             'form_params' => [
                 'grant_type' => self::API_ACCESS_TOKEN_REFRESH_TOKEN_GRANT,
                 'client_id' => $this->clientId,
                 'client_secret' => $this->clientSecret,
-                'refresh_token' => $accessToken->getRefreshToken()
+                'refresh_token' => $refreshToken
             ],
         ];
 

--- a/src/GuzzleIzettleClient.php
+++ b/src/GuzzleIzettleClient.php
@@ -108,6 +108,25 @@ class GuzzleIzettleClient implements IzettleClientInterface
         return $this->accessToken;
     }
 
+    public function getAccessTokenFromApiTokenAssertion(string $assertion): AccessToken
+    {
+        $options = [
+            'form_params' => [
+                'grant_type' => self::API_ACCESS_ASSERTION_GRANT,
+                'client_id' => $this->clientId,
+                'assertion' => $assertion
+            ],
+        ];
+
+        try {
+            $this->setAccessToken($this->requestAccessToken(self::API_ACCESS_TOKEN_REQUEST_URL, $options));
+        } catch (ClientException $exception) {
+            GuzzleClientExceptionHandler::handleClientException($exception);
+        }
+
+        return $this->accessToken;
+    }
+
     public function refreshAccessToken(?AccessToken $accessToken =  null): AccessToken
     {
         $accessToken = $accessToken ?? $this->accessToken;
@@ -229,7 +248,7 @@ class GuzzleIzettleClient implements IzettleClientInterface
         return new AccessToken(
             $data['access_token'],
             new DateTimeImmutable(sprintf('+%d second', $data['expires_in'])),
-            $data['refresh_token']
+            $data['refresh_token'] ?? null
         );
     }
 }

--- a/src/IzettleClientInterface.php
+++ b/src/IzettleClientInterface.php
@@ -16,6 +16,7 @@ interface IzettleClientInterface
     const API_ACCESS_TOKEN_REQUEST_URL = self::API_BASE_URL . '/token';
     const API_ACCESS_TOKEN_PASSWORD_GRANT = 'password';
     const API_ACCESS_TOKEN_CODE_GRANT = 'authorization_code';
+    const API_ACCESS_ASSERTION_GRANT = 'urn:ietf:params:oauth:grant-type:jwt-bearer';
     const API_ACCESS_TOKEN_REFRESH_TOKEN_URL = self::API_BASE_URL . '/token';
     const API_ACCESS_TOKEN_REFRESH_TOKEN_GRANT = 'refresh_token';
 

--- a/tests/Unit/GuzzleIzettleClientTest.php
+++ b/tests/Unit/GuzzleIzettleClientTest.php
@@ -94,6 +94,45 @@ final class GuzzleIzettleClientTest extends TestCase
     /**
      * @test
      */
+    public function getAccessTokenFromApiTokenAssertion(): void
+    {
+        $accessToken = 'accessToken';
+        $expiresIn = 7200;
+        $assertion = str_repeat('3a8ba448-69c2-4b9d-b8f3-5f8c2c04a2df', 32);
+        $options = [
+            'headers' => ['Content-Type' => 'application/x-www-form-urlencoded'],
+            'form_params' => [
+                'grant_type' => GuzzleIzettleClient::API_ACCESS_ASSERTION_GRANT,
+                'client_id' => self::CLIENT_ID,
+                'assertion' => $assertion,
+            ],
+        ];
+
+        $guzzleClientMock = Mockery::mock(GuzzleClient::class);
+        $guzzleClientMock->shouldReceive('post')->withArgs([GuzzleIzettleClient::API_ACCESS_TOKEN_REQUEST_URL, $options])->once()->andReturnSelf();
+        $guzzleClientMock->shouldReceive('getBody')->once()->andReturnSelf();
+        $guzzleClientMock->shouldReceive('getContents')->once()->andReturn(json_encode(
+            [
+                'access_token' => $accessToken,
+                'expires_in' => $expiresIn
+            ]
+        ));
+
+
+        $accessTokenFactory = new GuzzleIzettleClient($guzzleClientMock, self::CLIENT_ID, self::CLIENT_SECRET);
+        $accessTokenObject =  $accessTokenFactory->getAccessTokenFromApiTokenAssertion($assertion);
+
+        self::assertSame($accessToken, $accessTokenObject->getToken());
+        self::assertNull($accessTokenObject->getRefreshToken());
+        self::assertEquals(
+            (new DateTime($expiresIn . ' second'))->format('Y-m-d H:i:s'),
+            $accessTokenObject->getExpires()->format('Y-m-d H:i:s')
+        );
+    }
+
+    /**
+     * @test
+     */
     public function refreshAccessToken(): void
     {
         $oldAccessToken = new AccessToken('accessToken', new DateTimeImmutable(), 'refreshToken');

--- a/tests/Unit/GuzzleIzettleClientTest.php
+++ b/tests/Unit/GuzzleIzettleClientTest.php
@@ -11,6 +11,7 @@ use GuzzleHttp\ClientInterface as GuzzleClientInterface;
 use LauLamanApps\IzettleApi\API\Universal\IzettlePostable;
 use LauLamanApps\IzettleApi\Client\AccessToken;
 use LauLamanApps\IzettleApi\Client\ApiScope;
+use LauLamanApps\IzettleApi\Client\Exception\AccessTokenNotRefreshableException;
 use LauLamanApps\IzettleApi\GuzzleIzettleClient;
 use Mockery;
 use PHPUnit\Framework\TestCase;
@@ -170,6 +171,11 @@ final class GuzzleIzettleClientTest extends TestCase
             (new DateTime($newExpiresIn . ' second'))->format('Y-m-d H:i:s'),
             $accessTokenObject->getExpires()->format('Y-m-d H:i:s')
         );
+
+        $fixedToken = new AccessToken('test', new DateTimeImmutable(), null);
+
+        $this->expectException(AccessTokenNotRefreshableException::class);
+        $accessTokenFactory->refreshAccessToken($fixedToken);
     }
 
     /**


### PR DESCRIPTION
Added a `getAccessTokenFromApiTokenAssertion` method to log in with API tokens.

It doesn't support refresh tokens, so I made that optional and added a check to ensure only access tokens with refresh tokens are renewed.

Closes #44