### PR TITLE
Add support for ramsey/uuid v4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "php": ">=7.3",
     "guzzlehttp/guzzle": "^6.3",
     "moneyphp/money": "^3.0",
-    "ramsey/uuid": "^3.7",
+    "ramsey/uuid": "^3.7 || ^4.0",
     "werkspot/enum": "^3.0",
     "ext-json": "*"
   },


### PR DESCRIPTION
This fixes incompatibility with Laravel 8.

`ramsey/uuid` version 4 adds UUID v6, and refines the package to return more strictly typed objects, but these are all backwards incompatible.

The new version does [introduce some deprecations][1], so it should be looked into if these are used, but I don't see any warnings about it.

[1]: https://github.com/ramsey/uuid/blob/master/CHANGELOG.md#deprecated-1
