### PR TITLE
Adding optional headers to handle rfc7386 required for some API calls

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -8,11 +8,11 @@ checks:
 build:
     environment:
         php:
-            version: 7.3
+            version: 8.1
     tests:
         override:
             -
-                command: 'make coverage'
+                command: 'composer run test-coverage'
                 coverage:
                     file: 'coverage/clover.xml'
                     format: 'php-clover'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: php
 
 php:
-  - '7.3'
-  - '7.4'
+  - '8.1'
+  - '8.2'
 
 dist: trusty
 

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
     "test-integration": "phpunit --testsuite integration",
     "test-coverage": [
       "rm -rf coverage || true",
-      "phpunit --coverage-html=coverage/ --coverage-clover=coverage/clover.xml"
+      "XDEBUG_MODE=coverage phpunit --coverage-html=coverage/ --coverage-clover=coverage/clover.xml"
     ],
     "format": "php-cs-fixer fix --verbose"
   },

--- a/src/API/Product/Variant.php
+++ b/src/API/Product/Variant.php
@@ -140,7 +140,7 @@ final class Variant
         ];
 
         if ($this->costPrice) {
-            $data['costPrice'] =[
+            $data['costPrice'] = [
                 'amount' => $this->costPrice->getAmount(),
                 'currencyId' => (string) $this->costPrice->getCurrency(),
             ];

--- a/src/Exception/UnprocessableEntityException.php
+++ b/src/Exception/UnprocessableEntityException.php
@@ -25,7 +25,7 @@ final class UnprocessableEntityException extends Exception implements IzettleApi
         parent::__construct($error['developerMessage'], 422);
 
         $this->errorType = $error['errorType'];
-        $this->violations = $error['violations'];
+        $this->violations = $error['violations'] ?? [];
     }
 
     public function getErrorType(): ?string

--- a/src/GuzzleIzettleClient.php
+++ b/src/GuzzleIzettleClient.php
@@ -151,9 +151,13 @@ class GuzzleIzettleClient implements IzettleClientInterface
         return $this->accessToken;
     }
 
-    public function get(string $url, ?array $queryParameters = null): ResponseInterface
+    public function get(string $url, ?array $queryParameters = null, ?array $customHeaders = []): ResponseInterface
     {
-        $options =  array_merge(['headers' => $this->getAuthorizationHeader()], ['query' => $queryParameters]);
+        $headers = array_merge(
+            $this->getAuthorizationHeader(),
+            $customHeaders
+        );
+        $options =  array_merge(['headers' => $headers], ['query' => $queryParameters]);
 
         try {
             $response = $this->guzzleClient->get($url, $options);
@@ -167,14 +171,15 @@ class GuzzleIzettleClient implements IzettleClientInterface
     /**
      * @throws UnprocessableEntityException
      */
-    public function post(string $url, IzettlePostable $postable): ResponseInterface
+    public function post(string $url, IzettlePostable $postable, ?array $customHeaders = []): ResponseInterface
     {
         $headers = array_merge(
             $this->getAuthorizationHeader(),
             [
                 'content-type' => 'application/json',
                 'Accept' => 'application/json',
-            ]
+            ],
+            $customHeaders
         );
 
         $options =  array_merge(['headers' => $headers], ['body' => $postable->getPostBodyData()]);
@@ -189,14 +194,15 @@ class GuzzleIzettleClient implements IzettleClientInterface
     /**
      * @throws UnprocessableEntityException
      */
-    public function put(string $url, string $jsonData): void
+    public function put(string $url, string $jsonData, ?array $customHeaders = []): void
     {
         $headers = array_merge(
             $this->getAuthorizationHeader(),
             [
                 'content-type' => 'application/json',
                 'Accept' => 'application/json',
-            ]
+            ],
+            $customHeaders
         );
 
         $options =  array_merge(['headers' => $headers], ['body' => $jsonData]);
@@ -211,10 +217,14 @@ class GuzzleIzettleClient implements IzettleClientInterface
     /**
      * @throws UnprocessableEntityException
      */
-    public function delete(string $url): void
+    public function delete(string $url, ?array $customHeaders = []): void
     {
+        $headers = array_merge(
+            $this->getAuthorizationHeader(),
+            $customHeaders
+        );
         try {
-            $this->guzzleClient->delete($url, ['headers' => $this->getAuthorizationHeader()]);
+            $this->guzzleClient->delete($url, ['headers' => $headers]);
         } catch (ClientException $exception) {
             throw new UnprocessableEntityException($exception->getResponse()->getBody()->getContents());
         }

--- a/src/GuzzleIzettleClient.php
+++ b/src/GuzzleIzettleClient.php
@@ -223,6 +223,7 @@ class GuzzleIzettleClient implements IzettleClientInterface
             $this->getAuthorizationHeader(),
             $customHeaders
         );
+
         try {
             $this->guzzleClient->delete($url, ['headers' => $headers]);
         } catch (ClientException $exception) {

--- a/tests/Integration/Client/ProductClientTest.php
+++ b/tests/Integration/Client/ProductClientTest.php
@@ -104,16 +104,16 @@ final class ProductClientTest extends AbstractClientTest
 
         foreach ($products as $index => $product) {
             $this->assertSame($data[$index]['uuid'], (string) $product->getUuid());
-//            $this->assertSame($data[$index]['categories'], $product->getCategories());
+            //            $this->assertSame($data[$index]['categories'], $product->getCategories());
             $this->assertSame($data[$index]['name'], $product->getName());
             $this->assertSame($data[$index]['description'], $product->getDescription());
-//            $this->assertSame($data[$index]['imageLookupKeys'], $product->getImageLookupKeys());
+            //            $this->assertSame($data[$index]['imageLookupKeys'], $product->getImageLookupKeys());
             $this->assertSame($data[$index]['externalReference'], $product->getExternalReference());
             $this->assertSame($data[$index]['etag'], $product->getEtag());
             $this->assertEquals(new DateTime($data[$index]['updated']), $product->getUpdatedAt());
             $this->assertSame($data[$index]['updatedBy'], (string) $product->getUpdatedBy());
             $this->assertEquals(new DateTime($data[$index]['created']), $product->getCreatedAt());
-//            $this->assertSame($data[$index]['unitName'], $product->getUnitName());
+            //            $this->assertSame($data[$index]['unitName'], $product->getUnitName());
             $this->assertSame((float) $data[$index]['vatPercentage'], $product->getVatPercentage());
         }
     }

--- a/tests/Unit/Api/Purchase/PurchaseHistoryTest.php
+++ b/tests/Unit/Api/Purchase/PurchaseHistoryTest.php
@@ -36,7 +36,7 @@ final class PurchaseHistoryTest extends TestCase
         $purchase = $this->getGeneratedPurchase();
         $purchaseHistory ->addPurchase($purchase);
 
-        $this->assertEquals(($initialPurchases +1), count($purchaseHistory->getPurchases()));
+        $this->assertEquals(($initialPurchases + 1), count($purchaseHistory->getPurchases()));
 
         $purchaseHistory ->removePurchase($purchase);
 

--- a/tests/Unit/Client/Product/CategoryBuilderTest.php
+++ b/tests/Unit/Client/Product/CategoryBuilderTest.php
@@ -92,7 +92,7 @@ final class CategoryBuilderTest extends TestCase
                     ],
                 ],
             ],
-            'Multiple Category' =>[
+            'Multiple Category' => [
                 [
                     [
                         'uuid' => (string) Uuid::uuid1(),

--- a/tests/Unit/Client/Product/VariantsBuilderTest.php
+++ b/tests/Unit/Client/Product/VariantsBuilderTest.php
@@ -76,7 +76,7 @@ final class VariantsBuilderTest extends TestCase
                     ],
                 ],
             ],
-            'multiple variant' =>[
+            'multiple variant' => [
                 [
                     [
                         "uuid" => (string) Uuid::uuid1(),

--- a/tests/Unit/GuzzleIzettleClientTest.php
+++ b/tests/Unit/GuzzleIzettleClientTest.php
@@ -61,8 +61,8 @@ final class GuzzleIzettleClientTest extends TestCase
         $accessToken = 'accessToken';
         $refreshToken = 'refreshToken';
         $expiresIn = 7200;
-        $username ='username';
-        $password ='password';
+        $username = 'username';
+        $password = 'password';
         $options = [
             'headers' => ['Content-Type' => 'application/x-www-form-urlencoded'],
             'form_params' => [

--- a/tests/Unit/GuzzleIzettleClientTest.php
+++ b/tests/Unit/GuzzleIzettleClientTest.php
@@ -20,6 +20,7 @@ use LauLamanApps\IzettleApi\GuzzleIzettleClient;
 use Mockery;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 
 /**
  * @small
@@ -316,9 +317,12 @@ final class GuzzleIzettleClientTest extends TestCase
     public function getJson(): void
     {
         $data = 'getJsonTest';
-        $responseMock =  Mockery::mock(ResponseInterface::class);
-        $responseMock->shouldReceive('getBody')->once()->andReturnSelf();
-        $responseMock->shouldReceive('getContents')->once()->andReturn($data);
+
+        $streamMock = Mockery::mock(StreamInterface::class);
+        $streamMock->shouldReceive('getContents')->once()->andReturn($data);
+
+        $responseMock = Mockery::mock(ResponseInterface::class);
+        $responseMock->shouldReceive('getBody')->once()->andReturn($streamMock);
 
         $izettleClient = new GuzzleIzettleClient(new GuzzleClient(), self::CLIENT_ID, self::CLIENT_SECRET);
         $izettleClient->setAccessToken($this->getAccessToken());


### PR DESCRIPTION
Adding optional headers to handle rfc7386 (JSON merge patch through HttpHeaders.IF_MATCH header) required for some API calls (like `/organizations/{organizationUuid}/products/v2/{productUuid}`)

Can be used like this
`$guzzleIzettleClient->put($url, $data, ['If-Match' => '*']);`